### PR TITLE
Enforce 'portrait' orientation

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -20,6 +20,7 @@
     <platform name="android">
         <preference name="android-minSdkVersion" value="10" />
         <preference name="android-targetSdkVersion" value="17" />
+        <preference name="Orientation" value="portrait" />
 
         <access origin="tel:*" launch-external="yes"/>
         <access origin="sms:*" launch-external="yes"/>


### PR DESCRIPTION
This disables rotation to `landscape` mode and resolves:
https://github.com/mozilla/webmaker-app/issues/1371